### PR TITLE
Throw an error in case of dependency mismatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const version = require('./lib/version');
 const { isInstrumentedBuild } = require('./lib/cli-flags');
 const BroccoliDebug = require('broccoli-debug');
 const calculateCacheKeyForTree = require('calculate-cache-key-for-tree');
+const VersionChecker = require('ember-cli-version-checker');
 
 function isProductionEnv() {
   let isProd = /production/.test(process.env.EMBER_ENV);
@@ -60,6 +61,19 @@ module.exports = {
 
   init() {
     this._super.init && this._super.init.apply(this, arguments);
+
+    let checker = new VersionChecker(this.parent);
+    let hasJQuery = checker.for('@ember/jquery').exists();
+    let hasEmberFetch = checker.for('ember-fetch').isAbove('6.0.0');
+    if (!hasJQuery && !hasEmberFetch) {
+      throw new Error(
+        'To use ember-data, you need either @ember/jquery or ember-fetch@>=6 ' +
+          'package. You may already have jquery in your app. In that case, ' +
+          'you will have to explicitely opt into it. More info here: ' +
+          'https://guides.emberjs.com/release/configuring-ember/optional-features/#toc_jquery-integration'
+      );
+    }
+
     this._prodLikeWarning();
     this.debugTree = BroccoliDebug.buildDebugCallback('ember-data');
     this.options = this.options || {};

--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
     "semver": "^5.6.0",
     "silent-error": "^1.1.1"
   },
-  "peerDependencies": {
-    "ember-fetch": "^6.2.2"
-  },
   "devDependencies": {
     "@babel/plugin-transform-typescript": "^7.2.0",
     "@ember-decorators/babel-transforms": "^5.1.4",


### PR DESCRIPTION
A project that consumes ember-data should have:
- either jquery
- or ember-fetch version 6.0.0 or above

Throw a build error if it's not the case.

Disclaimer: this PR forces the consuming app (or addon) to explicitely opt into jQuery (https://github.com/ember-learn/deprecation-app/pull/255/files). Is it acceptable?